### PR TITLE
Avoid crashing if an unlink inside purge fails.

### DIFF
--- a/NVRJS.js
+++ b/NVRJS.js
@@ -731,8 +731,17 @@ function purgeContinuous() {
 		Files.forEach((F) => {
 			const Path = path.join(config.system.storageVolume, 'NVRJS_SYSTEM', K);
 			delete Index[K][F]; // Index Entry
-			fs.unlinkSync(path.join(Path, `${F}.json`)); // Metafile
-			fs.unlinkSync(path.join(Path, `${F}${FileType}`)); // footage
+			try {
+				fs.unlinkSync(path.join(Path, `${F}.json`)); // Metafile
+			} catch(e) {
+				// file couldn't be removed, likely due to permission issue, flaky disk etc.
+				// not anything we can do about it, but don't crash.
+			}
+			try {
+				fs.unlinkSync(path.join(Path, `${F}${FileType}`)); // footage
+			} catch(e) {
+				// ditto
+			}
 		});
 	});
 }


### PR DESCRIPTION
We were seeing an issue where sometimes a call to fs.unlinkSync was failing when nvr-js was running a purge, which caused nvr-js to crash (often losing at least part of the current video files and associated metadata). In the worst case scenario, the problem persists on disk and after a restart, it crashes again next purge on the same file, etc.

The unlink could fail for any number of reasons -- permissions changing, a flaky disk, file inadvertently moved (such as to try to archive it), etc. In any event, the root cause isn't really fixable for nvr-js, but crashing is the worst case scenario.

This code "fixes" the issue by wrapping both unlinks in (separate) try/catch blocks and ignoring any errors. This way if either errors, the other is still attempted, and the Index itself is cleaned up, and nvr-js is able to continue working. If the file is still actually present on the disk, it'll effectively be ignored until the next time nvr-js is restarted, at which point the initial sync will find it, and it will probably get another chance at being deleted (or skipped again if the problem still hasn't been resolved).

I'm not thrilled with just ignoring the errors, but again, any error at this point is not really something nvr-js can *fix*, and we'd prefer uptime and continuous new footage to crashing in this case.

There is another unlinkSync call elsewhere in the code, but we've never seen any errors from that one (yet?), so I opted not to touch it.